### PR TITLE
Fix: Ensure cli_tdd.py saves JSON history

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3,27 +3,9 @@ from gemini_client import generate_discovery
 from web_search import search_company
 from prompts.system_prompt import build_prompt
 from redis_client import save_history
+from history_client import salvar_historico_json
 
-import json
 import os
-from datetime import datetime
-
-def salvar_historico_json(cliente, prompt, resposta):
-    historico_dir = "history"
-    os.makedirs(historico_dir, exist_ok=True)
-
-    now = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    filename = f"{historico_dir}/{cliente}_{now}.json"
-
-    historico = {
-        "cliente": cliente,
-        "data_hora": now,
-        "prompt": prompt,
-        "resposta": resposta
-    }
-
-    with open(filename, "w") as f:
-        json.dump(historico, f, indent=4)
 
 def main():
     print("=== ASTOLFO: CLIENT DISCOVERY ASSISTANT ===")

--- a/cli_tdd.py
+++ b/cli_tdd.py
@@ -1,24 +1,7 @@
-from redis_client import save_history, get_history
+from redis_client import save_history
+from history_client import get_last_history, salvar_historico_json
 import os
-import json
-from datetime import datetime
 from gemini_client import generate_discovery
-
-# Nova função para tentar recuperar o último histórico no Redis
-# ou no arquivo .md local
-
-def get_last_history(cliente):
-    historicos = get_history(cliente)
-    if historicos:
-        return historicos[-1]['resposta']
-
-    # fallback: buscar na pasta ./respostas
-    nome_arquivo = f"respostas/{cliente.lower().replace(' ', '_')}.md"
-    if os.path.exists(nome_arquivo):
-        with open(nome_arquivo, "r") as f:
-            return f.read()
-
-    return None
 
 def main():
     print("=== ASTOLFO: REFINAR RESPOSTA COM NOVAS INFORMAÇÕES ===")
@@ -63,6 +46,7 @@ Por favor, revise e atualize sua resposta anterior com base nas novas informaç�
     print(nova_resposta)
 
     save_history(cliente, prompt, nova_resposta)
+    salvar_historico_json(cliente, prompt, nova_resposta)
 
     with open(f"respostas/{cliente.lower().replace(' ', '_')}.md", "w") as f:
         f.write(nova_resposta)

--- a/history_client.py
+++ b/history_client.py
@@ -1,0 +1,34 @@
+import os
+import json
+from datetime import datetime
+from redis_client import get_history
+
+def salvar_historico_json(cliente, prompt, resposta):
+    historico_dir = "history"
+    os.makedirs(historico_dir, exist_ok=True)
+
+    now = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    filename = f"{historico_dir}/{cliente}_{now}.json"
+
+    historico = {
+        "cliente": cliente,
+        "data_hora": now,
+        "prompt": prompt,
+        "resposta": resposta
+    }
+
+    with open(filename, "w") as f:
+        json.dump(historico, f, indent=4)
+
+def get_last_history(cliente):
+    historicos = get_history(cliente)
+    if historicos:
+        return historicos[-1]['resposta']
+
+    # fallback: buscar na pasta ./respostas
+    nome_arquivo = f"respostas/{cliente.lower().replace(' ', '_')}.md"
+    if os.path.exists(nome_arquivo):
+        with open(nome_arquivo, "r") as f:
+            return f.read()
+
+    return None


### PR DESCRIPTION
The `cli_tdd.py` script was not saving a JSON snapshot of the refined response to the `history/` directory. This contradicted the documented behavior in `README.md`, which states that JSON snapshots of each run should be saved. This resulted in an incomplete local history.

This commit fixes this bug by:
1. Extracting the `salvar_historico_json` and `get_last_history` functions into a shared `history_client.py` module to avoid code duplication.
2. Updating `cli.py` to use the new module.
3. Updating `cli_tdd.py` to call `salvar_historico_json` after a response is refined, ensuring the JSON history is saved correctly.